### PR TITLE
Remove dashes from formula ID

### DIFF
--- a/src/poetry_brew/templates.py
+++ b/src/poetry_brew/templates.py
@@ -5,7 +5,7 @@ from jinja2 import Environment, BaseLoader
 env = Environment(loader=BaseLoader(), trim_blocks=True)
 
 FORMULA_TEMPLATE = env.from_string(dedent("""\
-    class {{ package.name|title }} < Formula
+    class {{ package.name|title|replace("-", "") }} < Formula
       include Language::Python::Virtualenv
       
       desc "{{ package.description }}"


### PR DESCRIPTION
Nothing prevent a package name to contain dashes. For instance, my [`meta-package-manager` project](https://github.com/kdeldycke/meta-package-manager/blob/314afb96321b9f8d854136395842b510303a2da4/pyproject.toml#L3).

Using `poetry-brew`, a `meta-package-manager.rb` formula is produced that starts with:
```ruby
class Meta-Package-Manager < Formula
    (...)
```

This does not make `brew` happy:
```shell-session
$ brew install --build-from-source meta-package-manager
==> Downloading https://formulae.brew.sh/api/formula.jws.json
######################################################################## 100.0%
==> Downloading https://formulae.brew.sh/api/cask.jws.json
######################################################################## 100.0%
Error: meta-package-manager: ~/homebrew-core/Formula/meta-package-manager.rb:1: syntax error, unexpected '-'
class Meta-Package-Manager < Formula
          ^
```

So this PR remove any occurence of dashes in the class name produced by the template.