### PR TITLE
Use canonical Python dependency & remove optional `virtualenv_create` directive

### DIFF
--- a/src/poetry_brew/templates.py
+++ b/src/poetry_brew/templates.py
@@ -7,16 +7,16 @@ env = Environment(loader=BaseLoader(), trim_blocks=True)
 FORMULA_TEMPLATE = env.from_string(dedent("""\
     class {{ package.name|title }} < Formula
       include Language::Python::Virtualenv
-      
+
       desc "{{ package.description }}"
       homepage "{{ package.homepage }}"
       url "{{ package.url }}"
       sha256 "{{ package.checksum }}"
-      
-      depends_on "python3"
+
+      depends_on "python@3.11"
       {% for dependency in dependencies %}depends_on "{{ dependency }}"
       {% endfor %}
-      
+
     {% if resources %}
     {% for resource in resources %}
       resource "{{ resource.name }}" do
@@ -28,11 +28,9 @@ FORMULA_TEMPLATE = env.from_string(dedent("""\
     {% endif %}
 
       def install
-    {% if python == "python3" %}
-        virtualenv_create(libexec, "python3")
-    {% endif %}
         virtualenv_install_with_resources
       end
+
       test do
         false
       end


### PR DESCRIPTION
I used `poetry-brew` to create a Formula for my Python CLI at: https://github.com/Homebrew/homebrew-core/pull/127591

I uncovered some issue with the default template and this PR try to fix them. Namely:

* An issue with conformance to the Homebrew guidelines, i.e. the dependency should not be declared on `python3` which is an alias, but on `python@3.11`, which is the canonical name. [See the audit report](https://github.com/Homebrew/homebrew-core/actions/runs/4616327662/jobs/8161202142#step:4:25), which returns:

```shell-session
$ brew test-bot --only-tap-syntax
==> Using Homebrew/homebrew-test-bot dc5078c (Merge pull request #899 from Homebrew/formula_detect_cask)
==> Using Homebrew/brew 4.0.11-56-g1c87b8e67 (Merge pull request #15148 from ZhongRuoyu/commands-command_description)
==> Testing Homebrew/homebrew-core ddf8febe338 (Merge 76695460f0d8969d96f5e23e09a487243c49ba0a into 6e79ffce447c18112ed09a075c199805d0a4a04d):

==> Running TapSyntax#run!
==> brew style homebrew/core
==> brew readall --aliases homebrew/core
==> brew audit --tap=homebrew/core
==> FAILED
Full audit --tap=homebrew/core output
  meta-package-manager:
    * Dependency 'python3' is an alias; use the canonical name 'python@3.11'.
  Error: 1 problem in 1 formula detected
Error: 1 failed step!
brew audit --tap=homebrew/core
Error: Process completed with exit code 1.
```

* [`virtualenv_create` directive is no longer needed, as per the review](https://github.com/Homebrew/homebrew-core/pull/127591#discussion_r1158215987).

* I used that opportunity to remove blank spaces and adding a new line to separate sections.